### PR TITLE
[Dubbo-2031] Fix hessian2 serialization infinit recursion(StackOverflowError) when object's writeReplace method returns the object itself

### DIFF
--- a/src/main/java/com/alibaba/com/caucho/hessian/io/JavaSerializer.java
+++ b/src/main/java/com/alibaba/com/caucho/hessian/io/JavaSerializer.java
@@ -219,13 +219,17 @@ public class JavaSerializer extends AbstractSerializer {
                 else
                     repl = _writeReplace.invoke(obj);
 
-                out.removeRef(obj);
+                //Some class would return itself for wrapReplace, which would cause infinite recursion
+                //In this case, we could write the object just like normal cases
+                if (repl != obj) {
+                    out.removeRef(obj);
 
-                out.writeObject(repl);
+                    out.writeObject(repl);
 
-                out.replaceRef(repl, obj);
+                    out.replaceRef(repl, obj);
 
-                return;
+                    return;
+                }
             }
         } catch (RuntimeException e) {
             throw e;

--- a/src/test/java/com/alibaba/com/caucho/hessian/io/writereplace/Hessian2WriteReplaceTest.java
+++ b/src/test/java/com/alibaba/com/caucho/hessian/io/writereplace/Hessian2WriteReplaceTest.java
@@ -1,0 +1,114 @@
+package com.alibaba.com.caucho.hessian.io.writereplace;
+
+import static org.junit.Assert.assertEquals;
+
+import com.alibaba.com.caucho.hessian.io.base.SerializeTestBase;
+import java.io.Serializable;
+import org.junit.Test;
+
+
+public class Hessian2WriteReplaceTest extends SerializeTestBase {
+
+  @Test
+  public void testWriteReplaceReturningItself() throws Exception {
+    String someName = "some name";
+    WriteReplaceReturningItself object = new WriteReplaceReturningItself(someName);
+
+    WriteReplaceReturningItself result = baseHessian2Serialize(object);
+
+    assertEquals(someName, result.getName());
+  }
+
+  @Test
+  public void testNormalWriteReplace() throws Exception {
+    String someFirstName = "first";
+    String someLastName = "last";
+    String someAddress = "some address";
+
+    NormalWriteReplace object = new NormalWriteReplace(someFirstName, someLastName, someAddress);
+
+    NormalWriteReplace result = baseHessian2Serialize(object);
+
+    assertEquals(someFirstName, result.getFirstName());
+    assertEquals(someLastName, result.getLastName());
+    assertEquals(someAddress, result.getAddress());
+  }
+
+  static class WriteReplaceReturningItself implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String name;
+
+    WriteReplaceReturningItself(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    /**
+     * Some object may return itself for wrapReplace, e.g.
+     * https://github.com/FasterXML/jackson-databind/blob/master/src/main/java/com/fasterxml/jackson/databind/JsonMappingException.java#L173
+     */
+    Object writeReplace() {
+      //do some extra things
+
+      return this;
+    }
+  }
+
+  static class NormalWriteReplace implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String firstName;
+    private String lastName;
+    private String address;
+
+    public NormalWriteReplace(String firstName, String lastName, String address) {
+      this.firstName = firstName;
+      this.lastName = lastName;
+      this.address = address;
+    }
+
+    public String getFirstName() {
+      return firstName;
+    }
+
+    public String getLastName() {
+      return lastName;
+    }
+
+    public String getAddress() {
+      return address;
+    }
+
+    //return a proxy to save space for serialization
+    Object writeReplace() {
+      return new NormalWriteReplaceProxy(this);
+    }
+  }
+
+  static class NormalWriteReplaceProxy implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String data;
+
+    //empty constructor for deserialization
+    public NormalWriteReplaceProxy() {
+    }
+
+    public NormalWriteReplaceProxy(NormalWriteReplace normalWriteReplace) {
+      this.data = normalWriteReplace.getFirstName() + "," + normalWriteReplace.getLastName() + "," + normalWriteReplace
+          .getAddress();
+    }
+
+    //construct the actual object
+    Object readResolve() {
+      String[] parts = data.split(",");
+
+      return new NormalWriteReplace(parts[0], parts[1], parts[2]);
+    }
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix [#2031](https://github.com/apache/incubator-dubbo/issues/2031)

## Brief changelog

When the object's writeReplace return itself, then just serialize it as the normal object. No need to do another recursive call, which will cause infinite recursion.

## Verifying this change

Check the newly added unit test case: Hessian2WriteReplaceTest.java